### PR TITLE
Round px result to nearest full integer

### DIFF
--- a/tasks/remfallback.js
+++ b/tasks/remfallback.js
@@ -63,7 +63,7 @@ module.exports = function(grunt){
 
             // replace 'rem' and anything that comes after it, we'll repair this later
             var unitlessValue = v.replace(/rem.*/, '');
-            var pxValue = preciseRound(unitlessValue * rootSize, 1) + 'px';
+            var pxValue = preciseRound(unitlessValue * rootSize, 0) + 'px';
             var newValue = restValue ? pxValue + restValue : pxValue;
 
             remFound++;


### PR DESCRIPTION
When using precise rem units, running remfallback would produce some questionable px results (e.g. 20px HTML font-size, 1.55rem = 24.8px). This minor rounding change prevents non-full integers for returned px values.
