### PR TITLE
Ignore rem values in calc functions, optionally ignore mediaqueries and ...

### DIFF
--- a/tasks/remfallback.js
+++ b/tasks/remfallback.js
@@ -21,7 +21,8 @@ module.exports = function(grunt) {
       log: false,
       replace: false,
       ignoreUnsupported: true,
-      mediaQuery: false
+      mediaQuery: false,
+      round: false
     });
 
     this.files.forEach(function(f) {
@@ -49,7 +50,8 @@ module.exports = function(grunt) {
           unsupportedProperties = ['transform', 'perspective', 'background-size'];
 
       // round floating numbers
-      function preciseRound(num, decimals) {
+      function preciseRound(num) {
+        var decimals = options.round ? 0 : 1;
         return Math.round(num * Math.pow(10, decimals)) / Math.pow(10, decimals);
       }
 
@@ -82,7 +84,7 @@ module.exports = function(grunt) {
 
             // replace 'rem' and anything that comes after it, we'll repair this later
             var unitlessValue = v.replace(/rem.*/, '');
-            var pxValue = preciseRound(unitlessValue * rootSize, 0) + 'px';
+            var pxValue = preciseRound(unitlessValue * rootSize) + 'px';
             var newValue = restValue ? pxValue + restValue : pxValue;
 
             remFound++;


### PR DESCRIPTION
Hi!
Your grunt plugin is the only one that manages to find the root size so I've been using it for a while. The problem is it breaks on calc() calls since you split up the properties using whitespaces. I've changed the plugin to split properties considering the whitespaces inside calc and to ignore those even if they contain rem values, since they are not supported by IE8 anyway. I also added an option to ignore declarations inside media queries, because not everybody uses polyfills for that and then it just bloats your stylesheet. The same goes for unsupported properties like 'transform', 'background-size' or multiple backgrounds positioning. See if you like it! 
