### PR TITLE
Remove redundant iterator

### DIFF
--- a/tasks/remfallback.js
+++ b/tasks/remfallback.js
@@ -170,7 +170,6 @@ module.exports = function(grunt) {
               rule.declarations.splice(i, 0, fallback);
             }
 
-            i++;
           }
         }
       }


### PR DESCRIPTION
I know you've probably moved on from this and that not too many people have to worry about supporting IE8 any longer, but this meets a need I have on a current project.

In case you're interested still, here's a PR to fix a problem with the for loop in `findRems`. It was iterating twice for each pass through the loop, thus skipping every second rule declaration. (This also resolves issue #4 I think.)

Thanks.